### PR TITLE
Replace outdated NDJSON spec link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://github.com/olivere/ndjson/workflows/Test/badge.svg)](https://github.com/olivere/ndjson/actions)
 
 The `ndjson` package implements reading and writing files according
-to the [ndjson specification](http://ndjson.org/).
+to the [ndjson specification](https://github.com/ndjson/ndjson-spec/).
 
 Example:
 

--- a/doc.go
+++ b/doc.go
@@ -1,5 +1,5 @@
 /*
 Package ndjson implements reading and writing files according to
-the ndjson specification (http://ndjson.org/).
+the ndjson specification (https://github.com/ndjson/ndjson-spec/).
 */
 package ndjson

--- a/reader.go
+++ b/reader.go
@@ -11,7 +11,7 @@ var (
 )
 
 // Reader allows reading line-oriented JSON data following the
-// ndjson spec at http://ndjson.org/.
+// ndjson spec at https://github.com/ndjson/ndjson-spec/.
 type Reader struct {
 	r io.Reader
 	s *bufio.Scanner

--- a/writer.go
+++ b/writer.go
@@ -10,7 +10,7 @@ var (
 )
 
 // Writer implements writing line-oriented JSON data following the
-// ndjson spec at http://ndjson.org/.
+// ndjson spec at https://github.com/ndjson/ndjson-spec/.
 type Writer struct {
 	w   io.Writer
 	enc *json.Encoder


### PR DESCRIPTION
The old spec site at http://ndjson.org/ is no longer active -- or at least not in a relevant capacity. The spec is now maintained in [this Github repository](https://github.com/ndjson/ndjson-spec). This quick PR replaces links to the old site with links to the repository. 